### PR TITLE
Qt4 support

### DIFF
--- a/src/bintreenodereader.cpp
+++ b/src/bintreenodereader.cpp
@@ -26,8 +26,13 @@
  * official policies, either expressed or implied, of the copyright holder.
  */
 
-#include <QGuiApplication>
 #include <QDataStream>
+
+#if QT_VERSION >= QT_VERSION_CHECK(5,0,0)
+#include <QGuiApplication>
+#else
+#include <QApplication>
+#endif
 
 #include "attributelist.h"
 #include "bintreenodereader.h"

--- a/src/keystream.h
+++ b/src/keystream.h
@@ -31,7 +31,12 @@
 
 #include <QObject>
 #include <QByteArray>
+
+#if QT_VERSION >= QT_VERSION_CHECK(5,0,0)
 #include <QMessageAuthenticationCode>
+#else
+#include <QCryptographicHash>
+#endif
 
 #include "rc4.h"
 
@@ -50,10 +55,16 @@ public:
 
 private:
     QByteArray processBuffer(QByteArray buffer, int seq = 0);
+
+#if QT_VERSION >= QT_VERSION_CHECK(5,0,0)
     QByteArray hmacSha1(const QByteArray &data);
+    QMessageAuthenticationCode *mac;
+#else
+    QByteArray m_key;
+    QByteArray hmacSha1(QByteArray key, QByteArray baseString);
+#endif
 
     RC4 *rc4;
-    QMessageAuthenticationCode *mac;
     int seq;
 
 };

--- a/src/qexception/qexception.cpp
+++ b/src/qexception/qexception.cpp
@@ -1,4 +1,4 @@
-    /****************************************************************************
+/****************************************************************************
     **
     ** Copyright (C) 2015 The Qt Company Ltd.
     ** Contact: http://www.qt.io/licensing/
@@ -30,12 +30,12 @@
     ** $QT_END_LICENSE$
     **
     ****************************************************************************/
-    #include "qexception.h"
-    #include "QtCore/qshareddata.h"
-    #ifndef QT_NO_QFUTURE
-    #ifndef QT_NO_EXCEPTIONS
-    QT_BEGIN_NAMESPACE
-    /*!
+#include "qexception.h"
+#include "QtCore/qshareddata.h"
+#ifndef QT_NO_QFUTURE
+#ifndef QT_NO_EXCEPTIONS
+QT_BEGIN_NAMESPACE
+/*!
     \class QException
     \inmodule QtCore
     \brief The QException class provides a base class for exceptions that can transferred across threads.
@@ -58,17 +58,17 @@
     \li QFuture::results()
     \endlist
     */
-    /*!
+/*!
     \fn QException::raise() const
     In your QException subclass, reimplement raise() like this:
     \snippet code/src_corelib_thread_qexception.cpp 2
     */
-    /*!
+/*!
     \fn QException::clone() const
     In your QException subclass, reimplement clone() like this:
     \snippet code/src_corelib_thread_qexception.cpp 3
     */
-    /*!
+/*!
     \class QUnhandledException
     \inmodule QtCore
     \brief The UnhandledException class represents an unhandled exception in a worker thread.
@@ -78,81 +78,81 @@
     on the receiver thread side.
     Inheriting from this class is not supported.
     */
-    /*!
+/*!
     \fn QUnhandledException::raise() const
     \internal
     */
-    /*!
+/*!
     \fn QUnhandledException::clone() const
     \internal
     */
-    void QException::raise() const
-    {
+void QException::raise() const
+{
     QException e = *this;
     throw e;
-    }
-    QException *QException::clone() const
-    {
+}
+QException *QException::clone() const
+{
     return new QException(*this);
-    }
-    void QUnhandledException::raise() const
-    {
+}
+void QUnhandledException::raise() const
+{
     QUnhandledException e = *this;
     throw e;
-    }
-    QUnhandledException *QUnhandledException::clone() const
-    {
+}
+QUnhandledException *QUnhandledException::clone() const
+{
     return new QUnhandledException(*this);
-    }
-    #ifndef Q_QDOC
-    namespace QtPrivate {
-    class Base : public QSharedData
-    {
-    public:
+}
+#ifndef Q_QDOC
+namespace QtPrivate {
+class Base : public QSharedData
+{
+public:
     Base(QException *exception)
-    : exception(exception), hasThrown(false) { }
+        : exception(exception), hasThrown(false) { }
     ~Base() { delete exception; }
     QException *exception;
     bool hasThrown;
-    };
-    ExceptionHolder::ExceptionHolder(QException *exception)
+};
+ExceptionHolder::ExceptionHolder(QException *exception)
     : base(new Base(exception)) {}
-    ExceptionHolder::ExceptionHolder(const ExceptionHolder &other)
+ExceptionHolder::ExceptionHolder(const ExceptionHolder &other)
     : base(other.base)
-    {}
-    void ExceptionHolder::operator=(const ExceptionHolder &other)
-    {
+{}
+void ExceptionHolder::operator=(const ExceptionHolder &other)
+{
     base = other.base;
-    }
-    ExceptionHolder::~ExceptionHolder()
-    {}
-    QException *ExceptionHolder::exception() const
-    {
+}
+ExceptionHolder::~ExceptionHolder()
+{}
+QException *ExceptionHolder::exception() const
+{
     return base->exception;
-    }
-    void ExceptionStore::setException(const QException &e)
-    {
+}
+void ExceptionStore::setException(const QException &e)
+{
     if (hasException() == false)
-    exceptionHolder = ExceptionHolder(e.clone());
-    }
-    bool ExceptionStore::hasException() const
-    {
+        exceptionHolder = ExceptionHolder(e.clone());
+}
+bool ExceptionStore::hasException() const
+{
     return (exceptionHolder.exception() != 0);
-    }
-    ExceptionHolder ExceptionStore::exception()
-    {
+}
+ExceptionHolder ExceptionStore::exception()
+{
     return exceptionHolder;
-    }
-    void ExceptionStore::throwPossibleException()
-    {
+}
+void ExceptionStore::throwPossibleException()
+{
     if (hasException() ) {
-    exceptionHolder.base->hasThrown = true;
-    exceptionHolder.exception()->raise();
+        exceptionHolder.base->hasThrown = true;
+        exceptionHolder.exception()->raise();
     }
-    }
-    bool ExceptionStore::hasThrown() const { return exceptionHolder.base->hasThrown; }
-    } // namespace QtPrivate
-    #endif //Q_QDOC
-    QT_END_NAMESPACE
-    #endif // QT_NO_EXCEPTIONS
-    #endif // QT_NO_QFUTURE
+}
+bool ExceptionStore::hasThrown() const { return exceptionHolder.base->hasThrown; }
+} // namespace QtPrivate
+#endif //Q_QDOC
+QT_END_NAMESPACE
+#endif // QT_NO_EXCEPTIONS
+#endif // QT_NO_QFUTURE

--- a/src/qexception/qexception.cpp
+++ b/src/qexception/qexception.cpp
@@ -1,0 +1,158 @@
+    /****************************************************************************
+    **
+    ** Copyright (C) 2015 The Qt Company Ltd.
+    ** Contact: http://www.qt.io/licensing/
+    **
+    ** This file is part of the QtCore module of the Qt Toolkit.
+    **
+    ** $QT_BEGIN_LICENSE:LGPL21$
+    ** Commercial License Usage
+    ** Licensees holding valid commercial Qt licenses may use this file in
+    ** accordance with the commercial license agreement provided with the
+    ** Software or, alternatively, in accordance with the terms contained in
+    ** a written agreement between you and The Qt Company. For licensing terms
+    ** and conditions see http://www.qt.io/terms-conditions. For further
+    ** information use the contact form at http://www.qt.io/contact-us.
+    **
+    ** GNU Lesser General Public License Usage
+    ** Alternatively, this file may be used under the terms of the GNU Lesser
+    ** General Public License version 2.1 or version 3 as published by the Free
+    ** Software Foundation and appearing in the file LICENSE.LGPLv21 and
+    ** LICENSE.LGPLv3 included in the packaging of this file. Please review the
+    ** following information to ensure the GNU Lesser General Public License
+    ** requirements will be met: https://www.gnu.org/licenses/lgpl.html and
+    ** http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html.
+    **
+    ** As a special exception, The Qt Company gives you certain additional
+    ** rights. These rights are described in The Qt Company LGPL Exception
+    ** version 1.1, included in the file LGPL_EXCEPTION.txt in this package.
+    **
+    ** $QT_END_LICENSE$
+    **
+    ****************************************************************************/
+    #include "qexception.h"
+    #include "QtCore/qshareddata.h"
+    #ifndef QT_NO_QFUTURE
+    #ifndef QT_NO_EXCEPTIONS
+    QT_BEGIN_NAMESPACE
+    /*!
+    \class QException
+    \inmodule QtCore
+    \brief The QException class provides a base class for exceptions that can transferred across threads.
+    \since 5.0
+    Qt Concurrent supports throwing and catching exceptions across thread
+    boundaries, provided that the exception inherit from QException
+    and implement two helper functions:
+    \snippet code/src_corelib_thread_qexception.cpp 0
+    QException subclasses must be thrown by value and
+    caught by reference:
+    \snippet code/src_corelib_thread_qexception.cpp 1
+    If you throw an exception that is not a subclass of QException,
+    the Qt functions will throw a QUnhandledException
+    in the receiver thread.
+    When using QFuture, transferred exceptions will be thrown when calling the following functions:
+    \list
+    \li QFuture::waitForFinished()
+    \li QFuture::result()
+    \li QFuture::resultAt()
+    \li QFuture::results()
+    \endlist
+    */
+    /*!
+    \fn QException::raise() const
+    In your QException subclass, reimplement raise() like this:
+    \snippet code/src_corelib_thread_qexception.cpp 2
+    */
+    /*!
+    \fn QException::clone() const
+    In your QException subclass, reimplement clone() like this:
+    \snippet code/src_corelib_thread_qexception.cpp 3
+    */
+    /*!
+    \class QUnhandledException
+    \inmodule QtCore
+    \brief The UnhandledException class represents an unhandled exception in a worker thread.
+    \since 5.0
+    If a worker thread throws an exception that is not a subclass of QException,
+    the Qt functions will throw a QUnhandledException
+    on the receiver thread side.
+    Inheriting from this class is not supported.
+    */
+    /*!
+    \fn QUnhandledException::raise() const
+    \internal
+    */
+    /*!
+    \fn QUnhandledException::clone() const
+    \internal
+    */
+    void QException::raise() const
+    {
+    QException e = *this;
+    throw e;
+    }
+    QException *QException::clone() const
+    {
+    return new QException(*this);
+    }
+    void QUnhandledException::raise() const
+    {
+    QUnhandledException e = *this;
+    throw e;
+    }
+    QUnhandledException *QUnhandledException::clone() const
+    {
+    return new QUnhandledException(*this);
+    }
+    #ifndef Q_QDOC
+    namespace QtPrivate {
+    class Base : public QSharedData
+    {
+    public:
+    Base(QException *exception)
+    : exception(exception), hasThrown(false) { }
+    ~Base() { delete exception; }
+    QException *exception;
+    bool hasThrown;
+    };
+    ExceptionHolder::ExceptionHolder(QException *exception)
+    : base(new Base(exception)) {}
+    ExceptionHolder::ExceptionHolder(const ExceptionHolder &other)
+    : base(other.base)
+    {}
+    void ExceptionHolder::operator=(const ExceptionHolder &other)
+    {
+    base = other.base;
+    }
+    ExceptionHolder::~ExceptionHolder()
+    {}
+    QException *ExceptionHolder::exception() const
+    {
+    return base->exception;
+    }
+    void ExceptionStore::setException(const QException &e)
+    {
+    if (hasException() == false)
+    exceptionHolder = ExceptionHolder(e.clone());
+    }
+    bool ExceptionStore::hasException() const
+    {
+    return (exceptionHolder.exception() != 0);
+    }
+    ExceptionHolder ExceptionStore::exception()
+    {
+    return exceptionHolder;
+    }
+    void ExceptionStore::throwPossibleException()
+    {
+    if (hasException() ) {
+    exceptionHolder.base->hasThrown = true;
+    exceptionHolder.exception()->raise();
+    }
+    }
+    bool ExceptionStore::hasThrown() const { return exceptionHolder.base->hasThrown; }
+    } // namespace QtPrivate
+    #endif //Q_QDOC
+    QT_END_NAMESPACE
+    #endif // QT_NO_EXCEPTIONS
+    #endif // QT_NO_QFUTURE

--- a/src/qexception/qexception.h
+++ b/src/qexception/qexception.h
@@ -1,0 +1,91 @@
+/****************************************************************************
+    **
+    ** Copyright (C) 2015 The Qt Company Ltd.
+    ** Contact: http://www.qt.io/licensing/
+    **
+    ** This file is part of the QtCore module of the Qt Toolkit.
+    **
+    ** $QT_BEGIN_LICENSE:LGPL21$
+    ** Commercial License Usage
+    ** Licensees holding valid commercial Qt licenses may use this file in
+    ** accordance with the commercial license agreement provided with the
+    ** Software or, alternatively, in accordance with the terms contained in
+    ** a written agreement between you and The Qt Company. For licensing terms
+    ** and conditions see http://www.qt.io/terms-conditions. For further
+    ** information use the contact form at http://www.qt.io/contact-us.
+    **
+    ** GNU Lesser General Public License Usage
+    ** Alternatively, this file may be used under the terms of the GNU Lesser
+    ** General Public License version 2.1 or version 3 as published by the Free
+    ** Software Foundation and appearing in the file LICENSE.LGPLv21 and
+    ** LICENSE.LGPLv3 included in the packaging of this file. Please review the
+    ** following information to ensure the GNU Lesser General Public License
+    ** requirements will be met: https://www.gnu.org/licenses/lgpl.html and
+    ** http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html.
+    **
+    ** As a special exception, The Qt Company gives you certain additional
+    ** rights. These rights are described in The Qt Company LGPL Exception
+    ** version 1.1, included in the file LGPL_EXCEPTION.txt in this package.
+    **
+    ** $QT_END_LICENSE$
+    **
+    ****************************************************************************/
+#ifndef QTCORE_QEXCEPTION_H
+#define QTCORE_QEXCEPTION_H
+#include <QtCore/qglobal.h>
+#ifndef QT_NO_QFUTURE
+#include <QtCore/qatomic.h>
+#include <QtCore/qshareddata.h>
+#ifndef QT_NO_EXCEPTIONS
+# include <exception>
+#endif
+QT_BEGIN_NAMESPACE
+#ifndef QT_NO_EXCEPTIONS
+class Q_CORE_EXPORT QException : public std::exception
+{
+public:
+    virtual void raise() const;
+    virtual QException *clone() const;
+};
+class Q_CORE_EXPORT QUnhandledException : public QException
+{
+public:
+    void raise() const;
+    QUnhandledException *clone() const;
+};
+namespace QtPrivate {
+class Base;
+class Q_CORE_EXPORT ExceptionHolder
+{
+public:
+    ExceptionHolder(QException *exception = 0);
+    ExceptionHolder(const ExceptionHolder &other);
+    void operator=(const ExceptionHolder &other);
+    ~ExceptionHolder();
+    QException *exception() const;
+    QExplicitlySharedDataPointer<Base> base;
+};
+class Q_CORE_EXPORT ExceptionStore
+{
+public:
+    void setException(const QException &e);
+    bool hasException() const;
+    ExceptionHolder exception();
+    void throwPossibleException();
+    bool hasThrown() const;
+    ExceptionHolder exceptionHolder;
+};
+} // namespace QtPrivate
+#else // QT_NO_EXCEPTIONS
+namespace QtPrivate {
+class Q_CORE_EXPORT ExceptionStore
+{
+public:
+    ExceptionStore() { }
+    inline void throwPossibleException() {}
+};
+} // namespace QtPrivate
+#endif // QT_NO_EXCEPTIONS
+QT_END_NAMESPACE
+#endif // QT_NO_QFUTURE
+#endif

--- a/src/qjson/parser.h
+++ b/src/qjson/parser.h
@@ -1,0 +1,97 @@
+/* This file is part of QJson
+ *
+ * Copyright (C) 2008 Flavio Castelli <flavio.castelli@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software Foundation.
+ * 
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#ifndef QJSON_PARSER_H
+#define QJSON_PARSER_H
+
+QT_BEGIN_NAMESPACE
+class QIODevice;
+class QVariant;
+QT_END_NAMESPACE
+
+/**
+ * Namespace used by QJson
+ */
+namespace QJson {
+
+  class ParserPrivate;
+
+  /**
+   * @brief Main class used to convert JSON data to QVariant objects
+   */
+  class QJSON_EXPORT Parser
+  {
+    public:
+      Parser();
+      ~Parser();
+
+      /**
+      * Read JSON string from the I/O Device and converts it to a QVariant object
+      * @param io Input output device
+      * @param ok if a conversion error occurs, *ok is set to false; otherwise *ok is set to true.
+      * @returns a QVariant object generated from the JSON string
+      */
+      QVariant parse(QIODevice* io, bool* ok = 0);
+
+      /**
+      * This is a method provided for convenience.
+      * @param jsonData data containing the JSON object representation
+      * @param ok if a conversion error occurs, *ok is set to false; otherwise *ok is set to true.
+      * @returns a QVariant object generated from the JSON string
+      * @sa errorString
+      * @sa errorLine
+      */
+      QVariant parse(const QByteArray& jsonData, bool* ok = 0);
+
+      /**
+      * This method returns the error message
+      * @returns a QString object containing the error message of the last parse operation
+      * @sa errorLine
+      */
+      QString errorString() const;
+
+      /**
+      * This method returns line number where the error occurred
+      * @returns the line number where the error occurred
+      * @sa errorString
+      */
+      int errorLine() const;
+
+      /**
+       * Sets whether special numbers (Infinity, -Infinity, NaN) are allowed as an extension to
+       * the standard
+       * @param  allowSpecialNumbers new value of whether special numbers are allowed
+       * @sa specialNumbersAllowed
+       */
+      void allowSpecialNumbers(bool allowSpecialNumbers);
+
+      /**
+       * @returns whether special numbers (Infinity, -Infinity, NaN) are allowed
+       * @sa allowSpecialNumbers
+       */
+      bool specialNumbersAllowed() const;
+
+    private:
+      Q_DISABLE_COPY(Parser)
+      ParserPrivate* const d;
+  };
+}
+
+#endif // QJSON_PARSER_H

--- a/src/waexception.h
+++ b/src/waexception.h
@@ -1,8 +1,13 @@
 #ifndef WAEXCEPTION_H
 #define WAEXCEPTION_H
 
-#include <QException>
 #include <QString>
+
+#if QT_VERSION >= QT_VERSION_CHECK(5,0,0)
+#include <QException>
+#else
+#include "qexception/qexception.h"
+#endif
 
 class WAException : public QException
 {

--- a/src/waregistration.cpp
+++ b/src/waregistration.cpp
@@ -2,11 +2,14 @@
 #include "warequest.h"
 #include "waconstants.h"
 
+#if QT_VERSION >= QT_VERSION_CHECK(5,0,0)
 #include <QJsonDocument>
 #include <QJsonParseError>
+#include <QUrlQuery>
+#endif
 
 #include <QNetworkAccessManager>
-#include <QUrlQuery>
+#include <QStringList>
 
 #include <QLocale>
 

--- a/src/warequest.h
+++ b/src/warequest.h
@@ -4,8 +4,11 @@
 #include <QObject>
 
 #include <QNetworkReply>
-#include <QUrlQuery>
 #include <QNetworkAccessManager>
+
+#if QT_VERSION >= QT_VERSION_CHECK(5,0,0)
+#include <QUrlQuery>
+#endif
 
 class WARequest : public QObject
 {
@@ -29,10 +32,13 @@ public slots:
 
 private:
     QUrl m_url;
-    QUrlQuery m_url_query;
     QString m_ua;
     QNetworkReply *m_reply;
     QNetworkAccessManager *m_nam;
+
+#if QT_VERSION >= QT_VERSION_CHECK(5,0,0)
+    QUrlQuery m_url_query;
+#endif
 
 };
 


### PR DESCRIPTION
Qt4 support added:
 - QException class was taken from [Qt5 repository](https://qt.gitorious.org/qt/qtbase/source/909e2b17cbc1e18f9347cb986b5af53f50aeddc5:src/corelib/thread)
 - QJsonDocument and etc. from Qt5 was replased with minimal [QJson parser](https://github.com/flavio/qjson)
 - QUrlQuery was replaced with QUrl::addQueryItem()
 - QMessageAuthenticationCode was replaced with hmacSha1() function from [Qt Wiki](http://qt-project.org/wiki/HMAC-SHA1)